### PR TITLE
Button fo wiki page array of classes support

### DIFF
--- a/assets/css/scrollup.css
+++ b/assets/css/scrollup.css
@@ -33,3 +33,13 @@
   opacity: 1;
   visibility: visible;
 }
+
+@media screen and (max-width: 1490px) {
+    #scrollUpButton {
+        opacity: 0.3 !important;
+    }
+
+    #scrollUpButton::after {
+        color: black;
+    }
+}

--- a/assets/js/scrollup.js
+++ b/assets/js/scrollup.js
@@ -36,7 +36,8 @@ humhub.module('scrollUpButton', function (module, require, $) {
 
         var $appendButtonTo = [
             new ParentElToAppend($('.layout-sidebar-container')),
-            new ParentElToAppend($('.wiki-menu'), 'fromRight'),
+            new ParentElToAppend($('.wiki-menu')),
+            new ParentElToAppend($('.task-list')),
             new ParentElToAppend($('#wallStream')),
         ]
 

--- a/assets/js/scrollup.js
+++ b/assets/js/scrollup.js
@@ -7,19 +7,58 @@ humhub.module('scrollUpButton', function (module, require, $) {
     var init = function () {
         var visible = false;
 
-        var $sidebar = $('.layout-sidebar-container');
-        if (!$('#wallStream').length || !$sidebar.length) {
+        var isSet = function (item) {
+            return !(typeof item === 'undefined' || item === null);
+        }
+        var checkIfExist = function (item) {
+            if (!isSet(item)) {
+                return false;
+            }
+            return item.length > 0;
+        }
+
+        // @position can be either default or fromRight side
+        function ParentElToAppend($parentEl, position = 'default') {
+            this.$parentEl = $parentEl;
+            this.position = position;
+        }
+
+        var getParentHtmlEl = function ($checkInArr) {
+            if (!checkIfExist($checkInArr)) {
+                return null;
+            }
+            var findFirstAcceptableElement = $checkInArr.find(el => checkIfExist(el.$parentEl));
+            if (!isSet(findFirstAcceptableElement) || !checkIfExist(findFirstAcceptableElement.$parentEl)) {
+                return null;
+            }
+            return findFirstAcceptableElement.$parentEl ? findFirstAcceptableElement.$parentEl : null
+        }
+
+        var $appendButtonTo = [
+            new ParentElToAppend($('.layout-sidebar-container')),
+            new ParentElToAppend($('.wiki-menu'), 'fromRight'),
+            new ParentElToAppend($('#wallStream')),
+        ]
+
+        if (!checkIfExist($appendButtonTo)) {
             return;
         }
 
-        var $btn = initButton($sidebar);
+        // var doesExit = checkIfExist();
+        var $addTo = getParentHtmlEl($appendButtonTo);
+
+        if (!$addTo) {
+            return;
+        }
+
+        var $btn = initButton($addTo);
         var $window = $(window);
         $window.scroll(function () {
             var show = $window.scrollTop() > module.config.scrollTop;
             if (!visible && show) {
                 $btn.addClass('show');
                 visible = true;
-            } else if(visible && !show) {
+            } else if (visible && !show) {
                 $btn.removeClass('show');
                 visible = false;
             }
@@ -36,9 +75,14 @@ humhub.module('scrollUpButton', function (module, require, $) {
 
         $container.append($btn);
 
-        if(!module.config.isCustomPosition) {
-            var left = $container.offset().left + ($container.width() / 2) - ($btn.width() / 2);
-            $btn.css({left: left + 'px'});
+        if (!module.config.isCustomPosition) {
+            if ($container.position === 'default') {
+                var left = $container.offset().left + ($container.width() / 2) - ($btn.width() / 2);
+                $btn.css({left: left + 'px'});
+            } else { // fromRight
+                var right = '5';
+                $btn.css({right: right + '%'});
+            }
         }
 
         return $btn;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelogs
+
+Date: *8/8/2020*
+- Enh: Styling changes; JS  support an array of classes to append to; You can choose between a default position and position from the right for such cases like a wiki  page 
+
 Date: *5/5/2020*
 - Enh: Increased minimum HumHub version to `v1.4.x`
 


### PR DESCRIPTION
Some styles were added to different screen sizes.
In JS you can add classes to which you want to append these buttons
Changelog updated.
```
// Object Consturctor:
// @position can be either default or fromRight side with % specifed in code 
function ParentElToAppend($parentEl, position = 'default') {
    this.$parentEl = $parentEl;
    this.position = position;
}

var $appendButtonTo = [
            new ParentElToAppend($('.layout-sidebar-container')),
            new ParentElToAppend($('.wiki-menu'), 'fromRight'),
            new ParentElToAppend($('#wallStream')),
]
// ...
// ...
// for the right side you can change this value it is set in %
var right = '5';
$btn.css({right: right + '%'});
```

There was a quesion considering these lines of code:
```
if (!$('#wallStream').length || !$sidebar.length) {
            return;
 }
```
Why do we have `!$('#wallStream').length` if it is never used in this file, Let me know, please!